### PR TITLE
v0.1.4

### DIFF
--- a/README.org
+++ b/README.org
@@ -30,6 +30,9 @@ Before evaluating the src block enable ~org-nix-shell-mode~ or manually load the
 See [[file:demo.org][demo.org]] with examples for Python and C.
 
 * Installation
+
+Make sure [[https://direnv.net/][direnv]] is installed on your system ([[https://github.com/nix-community/nix-direnv#installation][nix-community/nix-direnv#Installation]]).
+
 ** Manual
 
 First, put [[file:org-nix-shell.el][org-nix-shell.el]] in your load path.
@@ -60,7 +63,7 @@ With ~emacsWithPackagesFromUsePackage~ you can do:
     extraEmacsPackages = epkgs:
       [(epkgs.trivialBuild rec {
         pname = "org-nix-shell";
-        version = "v0.1.3";
+        version = "v0.1.4";
         packageRequires = [ epkgs.envrc ];
         src = pkgs.fetchFromGitHub {
           owner = "AntonHakansson";

--- a/org-nix-shell.el
+++ b/org-nix-shell.el
@@ -4,7 +4,7 @@
 
 ;; Maintainer: Anton Hakansson <anton@hakanssn.com>
 ;; URL: https://github.com/AntonHakansson/
-;; Version: 0.1.3
+;; Version: 0.1.4
 ;; Package-Requires: ((emacs "27.1") (org) (envrc))
 ;; Keywords: org-mode, org-babel, nix, nix-shell
 
@@ -55,6 +55,11 @@
 ;;
 ;;
 ;;; NEWS:
+;; Version 0.1.4
+;; - Display shell.nix derivation errors.
+;; - Don't reload envrc every time.
+;; - More tests.
+;;
 ;; Version 0.1.3
 ;; - Small bug fixes and missing dependencies
 ;; - Continuous Integration and testing workflow

--- a/shell.nix
+++ b/shell.nix
@@ -1,7 +1,9 @@
 { pkgs ? import <nixpkgs> {} }:
 pkgs.mkShell {
+  # nix-shell shell.nix -I nixpkgs=channel:nixos-unstable --pure --command "make test"
   buildInputs = [
     pkgs.git
+    pkgs.nix
     pkgs.cask
     pkgs.coreutils
     pkgs.which


### PR DESCRIPTION
Version 0.1.4
  - Display shell.nix derivation errors.
  - Don't reload envrc on org-ctrl-c-ctrl-c every time; reload only when nix shell src
    block change.
  - More tests.
